### PR TITLE
Support to: RFC: Escape PDO "?" parameter placeholder

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,7 +38,7 @@ class ServiceProvider extends LaravelServiceProvider
                 return;
             }
 
-            $sqlWithPlaceholders = str_replace(['%', '?'], ['%%', '%s'], $query->sql);
+            $sqlWithPlaceholders = str_replace(['%', '?', '%s%s'], ['%%', '%s', '?'], $query->sql);
 
             $bindings = $query->connection->prepareBindings($query->bindings);
             $pdo = $query->connection->getPdo();


### PR DESCRIPTION
Issue: https://github.com/overtrue/laravel-query-logger/issues/27
RFC: Escape PDO "?" parameter placeholder
https://wiki.php.net/rfc/pdo_escape_placeholders

"??" will be translated to "?", so added fix for the following code to work correctly:
DB::table('table_name')->whereRaw('jsonb_column ?? ?', ['key'])->get();