### PR TITLE
PDO::quote(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,7 +45,10 @@ class ServiceProvider extends LaravelServiceProvider
             $duration = $this->formatDuration($query->time / 1000);
 
             if (count($bindings) > 0) {
-                $realSql = vsprintf($sqlWithPlaceholders, array_map([$pdo, 'quote'], $bindings));
+                $realSql = vsprintf($sqlWithPlaceholders, array_map(
+                    static fn($binding) => $binding === null ? 'NULL' : $pdo->quote($binding),
+                    $bindings
+                ));
             }
             Log::channel(config('logging.query.channel', config('logging.default')))
                 ->debug(sprintf('[%s] [%s] %s | %s: %s', $query->connection->getDatabaseName(), $duration, $realSql,


### PR DESCRIPTION
PDO::quote(): Passing null to parameter #1 ($string) of type string is deprecated in .../vendor/overtrue/laravel-query-logger/src/ServiceProvider.php on line 48