### PR TITLE
Fix placeholder interpolation for PostgreSQL JSONPath queries

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -40,19 +40,9 @@ class ServiceProvider extends LaravelServiceProvider
                 return;
             }
 
-            $sqlWithPlaceholders = str_replace(['%', '?', '%s%s'], ['%%', '%s', '?'], $query->sql);
-
-            $bindings = $query->connection->prepareBindings($query->bindings);
-            $pdo = $query->connection->getPdo();
-            $realSql = $sqlWithPlaceholders;
+            $realSql = $query->toRawSql();
             $duration = $this->formatDuration($query->time / 1000);
 
-            if (count($bindings) > 0) {
-                $realSql = vsprintf($sqlWithPlaceholders, array_map(
-                    static fn ($binding) => $binding === null ? 'NULL' : $pdo->quote($binding),
-                    $bindings
-                ));
-            }
             Log::channel(config('logging.query.channel', config('logging.default')))
                 ->debug(sprintf('[%s] [%s] %s | %s: %s', $query->connection->getDatabaseName(), $duration, $realSql,
                     request()->method(), request()->getRequestUri()));


### PR DESCRIPTION
## Summary

Replace the custom `vsprintf`-based SQL binding interpolation with Laravel's built-in `QueryExecuted::toRawSql()`.

## Problem

The current implementation replaces every `?` in the SQL string with `%s`:

~~~php
str_replace(['%', '?', '%s%s'], ['%%', '%s', '?'], $query->sql);
~~~

This incorrectly treats question marks inside SQL string literals as binding placeholders.

For example, PostgreSQL JSONPath queries may contain a literal `?`:

~~~sql
jsonb_path_exists(
    stage_dris,
    '$.*[*] ? (@ == $username)',
    jsonb_build_object(
        'username',
        to_jsonb(CAST(? AS text))
    )
)
~~~

This query contains one actual binding placeholder, but the logger detects two placeholders and throws:

~~~text
ValueError: The arguments array must contain 2 items, 1 given
~~~

The exception is raised by the query logger after the database query has executed successfully.

## Solution

Use Laravel's native SQL interpolation implementation:

~~~php
$realSql = $query->toRawSql();
~~~

Laravel's query grammar correctly distinguishes binding placeholders from question marks inside SQL string literals. It also handles database-specific operators without requiring the package to maintain its own SQL placeholder parser.

The package currently requires Laravel `^12.0|^13.0`, where `QueryExecuted::toRawSql()` is available.

## Verification

Verified using a PostgreSQL JSONPath query containing both:

- A literal `?` inside the JSONPath expression
- A real SQL binding placeholder

The generated raw SQL is:

~~~sql
select jsonb_path_exists(
    stage_dris,
    '$.*[*] ? (@ == $username)',
    jsonb_build_object(
        'username',
        to_jsonb(CAST('C0054917' AS text))
    )
)
~~~

Checks performed:

- PHP syntax check passed
- Laravel Pint passed
- The original `ValueError` is no longer thrown